### PR TITLE
e1000: Remove qerror_report

### DIFF
--- a/cpus.c
+++ b/cpus.c
@@ -1432,6 +1432,17 @@ static void tcg_exec_all(void)
 
         if (cpu_can_run(cpu)) {
             r = tcg_cpu_exec(cpu);
+            if (r == EXCP_TRIPLE) {
+                cpu_dump_state(cpu, stderr, fprintf, 0);
+                fprintf(stderr, "Triple fault.  Halting for inspection via"
+                        " QEMU monitor.\n");
+                if (gdbserver_running())
+                    r = EXCP_DEBUG;
+                else {
+                    vm_stop(RUN_STATE_DEBUG);
+                    break;
+                }
+            }
             if (r == EXCP_DEBUG) {
                 cpu_handle_guest_debug(cpu);
                 break;

--- a/gdbstub.c
+++ b/gdbstub.c
@@ -1767,3 +1767,8 @@ int gdbserver_start(const char *device)
     return 0;
 }
 #endif
+
+int gdbserver_running(void)
+{
+    return gdbserver_state != NULL;
+}

--- a/hw/net/e1000.c
+++ b/hw/net/e1000.c
@@ -35,6 +35,7 @@
 #include "qemu/iov.h"
 #include "qemu/range.h"
 #include "qapi/qmp/qerror.h"
+#include "qemu/error-report.h"
 
 #include "e1000_regs.h"
 
@@ -1738,8 +1739,8 @@ static void e1000_init_debug(void)
             }
         }
         if (!*debugname) {
-            qerror_report(QERR_INVALID_PARAMETER_VALUE, "E1000_DEBUG",
-                          "a comma-separated list of E1000 debug flags");
+            error_report(QERR_INVALID_PARAMETER_VALUE, "E1000_DEBUG",
+                         "a comma-separated list of E1000 debug flags");
             error_printf_unless_qmp(
                 "Try with argument '?' for a list.\n");
             exit(1);

--- a/hw/net/e1000.c
+++ b/hw/net/e1000.c
@@ -34,17 +34,29 @@
 #include "sysemu/dma.h"
 #include "qemu/iov.h"
 #include "qemu/range.h"
+#include "qapi/qmp/qerror.h"
 
 #include "e1000_regs.h"
 
 #define E1000_DEBUG
 
 #ifdef E1000_DEBUG
+#define E1000_FOR_DEBUG(x)                                              \
+    x(GENERAL)		x(IO)		x(MMIO)		x(INTERRUPT)    \
+    x(RX)		x(TX)		x(MDIC)		x(EEPROM)       \
+    x(UNKNOWN)		x(TXSUM)	x(TXERR)	x(RXERR)        \
+    x(RXFILTER)		x(PHY)		x(NOTYET)
+
 enum {
-    DEBUG_GENERAL,	DEBUG_IO,	DEBUG_MMIO,	DEBUG_INTERRUPT,
-    DEBUG_RX,		DEBUG_TX,	DEBUG_MDIC,	DEBUG_EEPROM,
-    DEBUG_UNKNOWN,	DEBUG_TXSUM,	DEBUG_TXERR,	DEBUG_RXERR,
-    DEBUG_RXFILTER,     DEBUG_PHY,      DEBUG_NOTYET,
+#define E1000_DEBUG_ENUM(name) DEBUG_##name,
+    E1000_FOR_DEBUG(E1000_DEBUG_ENUM)
+#undef E1000_DEBUG_ENUM
+};
+static const char *debugnames[] = {
+#define E1000_DEBUG_NAME(name) #name,
+    E1000_FOR_DEBUG(E1000_DEBUG_NAME)
+    NULL
+#undef E1000_DEBUG_NAME
 };
 #define DBGBIT(x)	(1<<DEBUG_##x)
 static int debugflags = DBGBIT(TXERR) | DBGBIT(GENERAL);
@@ -1691,3 +1703,51 @@ static void e1000_register_types(void)
 }
 
 type_init(e1000_register_types)
+
+#ifdef E1000_DEBUG
+static void e1000_init_debug(void)
+{
+    const char *e1000_debug;
+    const char *p, *p1;
+    const char **debugname;
+    int i;
+
+    e1000_debug = getenv("E1000_DEBUG");
+    if (!e1000_debug || !*e1000_debug)
+        return;
+
+    if (strcmp(e1000_debug, "?") == 0) {
+        error_printf("E1000_DEBUG flags:\n");
+        for (debugname = debugnames; *debugname; debugname++) {
+            error_printf("%s\n", *debugname);
+        }
+        exit(0);
+    }
+
+    p = e1000_debug;
+    debugflags = 0;
+    for (p = e1000_debug; ; p = p1 + 1) {
+        p1 = strchr(p, ',');
+        if (!p1)
+            p1 = p + strlen(p);
+        for (i = 0, debugname = debugnames; *debugname; i++, debugname++) {
+            if (strlen(*debugname) == p1 - p &&
+                strncasecmp(p, *debugname, p1 - p) == 0) {
+                debugflags |= 1<<i;
+                break;
+            }
+        }
+        if (!*debugname) {
+            qerror_report(QERR_INVALID_PARAMETER_VALUE, "E1000_DEBUG",
+                          "a comma-separated list of E1000 debug flags");
+            error_printf_unless_qmp(
+                "Try with argument '?' for a list.\n");
+            exit(1);
+        }
+        if (*p1 != ',')
+            break;
+    }
+}
+
+type_init(e1000_init_debug)
+#endif

--- a/include/exec/cpu-all.h
+++ b/include/exec/cpu-all.h
@@ -31,6 +31,7 @@
 #define EXCP_DEBUG      0x10002 /* cpu stopped after a breakpoint or singlestep */
 #define EXCP_HALTED     0x10003 /* cpu is halted (waiting for external event) */
 #define EXCP_YIELD      0x10004 /* cpu wants to yield timeslice to another */
+#define EXCP_TRIPLE     0x10005 /* cpu encountered triple fault */
 
 /* some important defines:
  *

--- a/include/exec/gdbstub.h
+++ b/include/exec/gdbstub.h
@@ -24,6 +24,7 @@ int gdb_handlesig(CPUState *, int);
 void gdb_signalled(CPUArchState *, int);
 void gdbserver_fork(CPUState *);
 #endif
+int gdbserver_running(void);
 /* Get or set a register.  Returns the size of the register.  */
 typedef int (*gdb_reg_cb)(CPUArchState *env, uint8_t *buf, int reg);
 void gdb_register_coprocessor(CPUState *cpu,

--- a/monitor.c
+++ b/monitor.c
@@ -1421,6 +1421,153 @@ static void hmp_boot_set(Monitor *mon, const QDict *qdict)
 }
 
 #if defined(TARGET_I386)
+/**
+ * PTLayout describes the layout of an x86 page table in enough detail
+ * to fully decode up to a 4-level 64-bit page table tree.
+ */
+typedef struct PTLayout {
+    int levels, entsize;
+    int entries[4];             /* Entries in each table level */
+    int shift[4];               /* VA bit shift each each level */
+    bool pse[4];                /* Whether PSE bit is valid */
+    const char *names[4];
+    int vaw, paw;               /* VA and PA width in characters */
+} PTLayout;
+
+/**
+ * PTIter provides a generic way to traverse and decode an x86 page
+ * table tree.
+ */
+typedef struct PTIter {
+    const PTLayout *layout;
+    bool pse;                   /* PSE enabled */
+    int level;                  /* Current level */
+    int i[4];                   /* Index at each level */
+    hwaddr base[4];             /* Physical base pointer */
+
+    uint64_t ent;               /* Current entry */
+    bool present, leaf;
+    target_ulong va;
+    hwaddr pa;
+    target_ulong  size;
+} PTIter;
+
+static bool ptiter_succ(PTIter *it);
+
+/**
+ * Initialize a PTIter to point to the first entry of the page table's
+ * top level.  On failure, prints a message to mon and returns false.
+ */
+static bool ptiter_init(Monitor *mon, PTIter *it)
+{
+    static const PTLayout l32 = {
+        2, 4, {1024, 1024}, {22, 12}, {1, 0}, {"PDE", "PTE"}, 8, 8
+    };
+    static const PTLayout lpae = {
+        3, 8, {4, 512, 512}, {30, 21, 12}, {0, 1, 0},
+        {"PDP", "PDE", "PTE"}, 8, 13
+    };
+#ifdef TARGET_X86_64
+    static const PTLayout l64 = {
+        4, 8, {512, 512, 512, 512}, {39, 30, 21, 12}, {0, 1, 1, 0},
+        {"PML4", "PDP", "PDE", "PTE"}, 12, 13
+    };
+#endif
+    CPUState *env;
+
+    env = mon_get_cpu();
+
+    if (!(env->cr[0] & CR0_PG_MASK)) {
+        monitor_printf(mon, "PG disabled\n");
+        return false;
+    }
+
+    memset(it, 0, sizeof(*it));
+    if (env->cr[4] & CR4_PAE_MASK) {
+#ifdef TARGET_X86_64
+        if (env->hflags & HF_LMA_MASK) {
+            it->layout = &l64;
+            it->base[0] = env->cr[3] & 0x3fffffffff000ULL;
+        } else
+#endif
+        {
+            it->layout = &lpae;
+            it->base[0] = env->cr[3] & ~0x1f;
+        }
+        it->pse = true;
+    } else {
+        it->layout = &l32;
+        it->base[0] = env->cr[3] & ~0xfff;
+        it->pse = (env->cr[4] & CR4_PSE_MASK);
+    }
+
+    /* Trick ptiter_succ into doing the hard initialization. */
+    it->i[0] = -1;
+    it->leaf = true;
+    ptiter_succ(it);
+    return true;
+}
+
+/**
+ * Move a PTIter to the successor of the current entry.  Specifically:
+ * if the iterator points to a leaf, move to its next sibling, or to
+ * the next sibling of a parent if it has no more siblings.  If the
+ * iterator points to a non-leaf, move to its first child.  If there
+ * is no successor, return false.
+ *
+ * Note that the resulting entry may not be marked present, though
+ * non-present entries are always leafs (within a page
+ * table/directory/etc, this will always visit all entries).
+ */
+static bool ptiter_succ(PTIter *it)
+{
+    int i, l, entsize;
+    uint64_t ent64;
+    uint32_t ent32;
+    bool large;
+
+    if (it->level < 0) {
+        return false;
+    } else if (!it->leaf) {
+        /* Move to this entry's first child */
+        it->level++;
+        it->base[it->level] = it->pa;
+        it->i[it->level] = 0;
+    } else {
+        /* Move forward and, if we hit the end of this level, up */
+        while (++it->i[it->level] == it->layout->entries[it->level]) {
+            if (it->level-- == 0) {
+                /* We're out of page table */
+                return false;
+            }
+        }
+    }
+
+    /* Read this entry */
+    l = it->level;
+    entsize = it->layout->entsize;
+    cpu_physical_memory_read(it->base[l] + it->i[l] * entsize,
+                             entsize == 4 ? (void *)&ent32 : (void *)&ent64,
+                             entsize);
+    if (entsize == 4) {
+        it->ent = le32_to_cpu(ent32);
+    } else {
+        it->ent = le64_to_cpu(ent64);
+    }
+
+    /* Decode the entry */
+    large = (it->pse && it->layout->pse[l] && (it->ent & PG_PSE_MASK));
+    it->present = it->ent & PG_PRESENT_MASK;
+    it->leaf = (large || !it->present || (l+1 == it->layout->levels));
+    it->va = 0;
+    for (i = 0; i <= l; i++) {
+        it->va |= (uint64_t)it->i[i] << it->layout->shift[i];
+    }
+    it->pa = it->ent & (large ? 0x3ffffffffc000ULL : 0x3fffffffff000ULL);
+    it->size = 1 << it->layout->shift[l];
+    return true;
+}
+
 static void print_pte(Monitor *mon, hwaddr addr,
                       hwaddr pte,
                       hwaddr mask)

--- a/monitor.c
+++ b/monitor.c
@@ -1473,7 +1473,7 @@ static bool ptiter_init(Monitor *mon, PTIter *it)
         {"PML4", "PDP", "PDE", "PTE"}, 12, 13
     };
 #endif
-    CPUState *env;
+    CPUArchState *env;
 
     env = mon_get_cpu();
 
@@ -1961,6 +1961,172 @@ static void hmp_info_mem(Monitor *mon, const QDict *qdict)
         }
     } else {
         mem_info_32(mon, env);
+    }
+}
+
+/* Return true if the page tree rooted at iter is complete and
+ * compatible with compat.  last will be filled with the last entry at
+ * each level.  If false, does not change iter and last can be filled
+ * with anything; if true, returns with iter at the next entry on the
+ * same level, or the next parent entry if iter is on the last entry
+ * of this level. */
+static bool pg_complete(PTIter *root, const PTIter compat[], PTIter last[])
+{
+    PTIter iter = *root;
+
+    if ((root->ent & 0xfff) != (compat[root->level].ent & 0xfff)) {
+        return false;
+    }
+
+    last[root->level] = *root;
+    ptiter_succ(&iter);
+    if (!root->leaf) {
+        /* Are all of the direct children of root complete? */
+        while (iter.level == root->level + 1) {
+            if (!pg_complete(&iter, compat, last)) {
+                return false;
+            }
+        }
+    }
+    assert(iter.level <= root->level);
+    assert(iter.level == root->level ?
+           iter.i[iter.level] == root->i[iter.level] + 1 : 1);
+    *root = iter;
+    return true;
+}
+
+static char *pg_bits(uint64_t ent)
+{
+    static char buf[32];
+    sprintf(buf, "%c%c%c%c%c%c%c%c%c%c",
+            /* TODO: Some of these change depending on level */
+            ent & PG_NX_MASK ? 'X' : '-',
+            ent & PG_GLOBAL_MASK ? 'G' : '-',
+            ent & PG_PSE_MASK ? 'S' : '-',
+            ent & PG_DIRTY_MASK ? 'D' : '-',
+            ent & PG_ACCESSED_MASK ? 'A' : '-',
+            ent & PG_PCD_MASK ? 'C' : '-',
+            ent & PG_PWT_MASK ? 'T' : '-',
+            ent & PG_USER_MASK ? 'U' : '-',
+            ent & PG_RW_MASK ? 'W' : '-',
+            ent & PG_PRESENT_MASK ? 'P' : '-');
+    return buf;
+}
+
+static void pg_print(Monitor *mon, PTIter *s, PTIter *l)
+{
+    int lev = s->level;
+    char buf[128];
+    char *pos = buf, *end = buf + sizeof(buf);
+
+    /* VFN range */
+    pos += sprintf(pos, "%*s[%0*"PRIx64"-%0*"PRIx64"] ",
+                   lev*2, "",
+                   s->layout->vaw - 3, (uint64_t)s->va >> 12,
+                   s->layout->vaw - 3, ((uint64_t)l->va + l->size - 1) >> 12);
+
+    /* Slot */
+    if (s->i[lev] == l->i[lev]) {
+        pos += sprintf(pos, "%4s[%03x]    ",
+                       s->layout->names[lev], s->i[lev]);
+    } else {
+        pos += sprintf(pos, "%4s[%03x-%03x]",
+                       s->layout->names[lev], s->i[lev], l->i[lev]);
+    }
+
+    /* Flags */
+    pos += sprintf(pos, " %s", pg_bits(s->ent));
+
+    /* Range-compressed PFN's */
+    if (s->leaf) {
+        PTIter iter = *s;
+        int i = 0;
+        bool exhausted = false;
+        while (!exhausted && i++ < 10) {
+            hwaddr pas = iter.pa, pae = iter.pa + iter.size;
+            while (ptiter_succ(&iter) && iter.va <= l->va) {
+                if (iter.level == s->level) {
+                    if (iter.pa == pae) {
+                        pae = iter.pa + iter.size;
+                    } else {
+                        goto print;
+                    }
+                }
+            }
+            exhausted = true;
+
+print:
+            if (pas >> 12 == (pae - 1) >> 12) {
+                pos += snprintf(pos, end-pos, " %0*"PRIx64,
+                                s->layout->paw - 3, (uint64_t)pas >> 12);
+            } else {
+                pos += snprintf(pos, end-pos, " %0*"PRIx64"-%0*"PRIx64,
+                                s->layout->paw - 3, (uint64_t)pas >> 12,
+                                s->layout->paw - 3, (uint64_t)(pae - 1) >> 12);
+            }
+            pos = MIN(pos, end);
+        }
+    }
+
+    /* Trim line to fit screen */
+    if (pos - buf > 79) {
+        strcpy(buf + 77, "..");
+    }
+
+    monitor_printf(mon, "%s\n", buf);
+}
+
+static void pg_info(Monitor *mon, const QDict *qdict)
+{
+    PTIter iter;
+
+    if (!ptiter_init(mon, &iter)) {
+        return;
+    }
+
+    /* Header line */
+    monitor_printf(mon, "%-*s %-13s %-10s %*s%s\n",
+                   3 + 2 * (iter.layout->vaw-3), "VPN range",
+                   "Entry", "Flags",
+                   2*(iter.layout->levels-1), "", "Physical page");
+
+    while (iter.level >= 0) {
+        int i, startLevel, maxLevel;
+        PTIter start[4], last[4], nlast[4];
+        bool compressed = false;
+
+        /* Skip to the next present entry */
+        do { } while (!iter.present && ptiter_succ(&iter));
+        if (iter.level < 0) {
+            break;
+        }
+
+        /* Find a run of complete entries starting at iter and staying
+         * on the same level. */
+        startLevel = iter.level;
+        memset(start, 0, sizeof(start));
+        do {
+            start[iter.level] = iter;
+        } while (!iter.leaf && ptiter_succ(&iter));
+        maxLevel = iter.level;
+        iter = start[startLevel];
+        while (iter.level == startLevel && pg_complete(&iter, start, nlast)) {
+            compressed = true;
+            memcpy(last, nlast, sizeof(last));
+        }
+
+        if (compressed) {
+            /* We found a run we can show as a range spanning
+             * [startLevel, maxLevel].  start stores the first entry
+             * at each level and last stores the last entry. */
+            for (i = startLevel; i <= maxLevel; i++) {
+                pg_print(mon, &start[i], &last[i]);
+            }
+        } else {
+            /* No luck finding a range.  Iter hasn't moved. */
+            pg_print(mon, &iter, &iter);
+            ptiter_succ(&iter);
+        }
     }
 }
 #endif
@@ -2773,6 +2939,13 @@ static mon_cmd_t info_cmds[] = {
         .params     = "",
         .help       = "show the active virtual memory mappings",
         .mhandler.cmd = hmp_info_mem,
+    },
+    {
+        .name       = "pg",
+        .args_type  = "",
+        .params     = "",
+        .help       = "show the page table",
+        .mhandler.cmd = pg_info,
     },
 #endif
     {

--- a/target-i386/excp_helper.c
+++ b/target-i386/excp_helper.c
@@ -64,8 +64,20 @@ static int check_exception(CPUX86State *env, int intno, int *error_code)
 
         qemu_log_mask(CPU_LOG_RESET, "Triple fault\n");
 
+#if 0
         qemu_system_reset_request();
         return EXCP_HLT;
+#else
+        /*
+         * QEMU traditionally resets the machine on triple fault
+         * because programs written for 286 protected mode would exit
+         * protected mode by intentionally triple faulting the machine
+         * (after setting the boot vector to point to their code).
+         * This sucks for debugging programs that were written after
+         * 1985, so we instead halt the machine for inspection.
+         */
+        return EXCP_TRIPLE;
+#endif
     }
 #endif
 


### PR DESCRIPTION
The `6.828-2.4.0` branch fails to compile for me. This is because Qemu 2.4.0 got rid of the `qerror_report` function.

This PR updates the E1000 debug flags patch to use `error_report` rather than `qerror_report`. With the patch in this PR applied, I am able to compile Qemu successfully. I have not explored the original E1000 patch enough to test if the debug functionality still works, but the change I made mirrors [a patch to remove calls to `qerror_report`](https://lists.gnu.org/archive/html/qemu-devel/2015-06/msg03568.html) that was submitted earlier this year (search for "QERR_INVALID_PARAMETER_VALUE").

This PR will probably be necessary to forward port the 6.828 patches to future versions of Qemu as well (2.5.0 was released a few weeks ago).
## How to reproduce

On OS X 10.11.2 with the latest Command Line Tools Installed (clang version  "Apple LLVM version 7.0.2 (clang-700.1.81)"), run the following:

```
$ git checkout 6.828-2.4.0
$ ./configure --disable-kvm --prefix=$PREFIX --target-list=x86_64-softmmu --disable-gtk
$ make
```
## Expected results

The `6.828-2.4.0` branch compiles with no implicit declaration warnings and links successfully.
## Actual results

The `6.828-2.4.0` prints implicit declaration warnings upon compiling, and fails to link. You can find the output below.

```
  CC    hw/net/e1000.o
hw/net/e1000.c:1720:9: warning: implicit declaration of function 'error_printf' is invalid in C99 [-Wimplicit-function-declaration]
        error_printf("E1000_DEBUG flags:\n");
        ^
hw/net/e1000.c:1741:13: warning: implicit declaration of function 'qerror_report' is invalid in C99 [-Wimplicit-function-declaration]
            qerror_report(QERR_INVALID_PARAMETER_VALUE, "E1000_DEBUG",
            ^
hw/net/e1000.c:1743:13: warning: implicit declaration of function 'error_printf_unless_qmp' is invalid in C99 [-Wimplicit-function-declaration]
            error_printf_unless_qmp(
            ^
3 warnings generated.
  LINK  x86_64-softmmu/qemu-system-x86_64
Undefined symbols for architecture x86_64:
  "_qerror_report", referenced from:
      _e1000_init_debug in e1000.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[1]: *** [qemu-system-x86_64] Error 1
make: *** [subdir-x86_64-softmmu] Error 2
```
